### PR TITLE
bump logs-service-broker

### DIFF
--- a/.final_builds/packages/golang-1-linux/index.yml
+++ b/.final_builds/packages/golang-1-linux/index.yml
@@ -7,4 +7,8 @@ builds:
     version: d55c618ac63dfdf4ac457346fb325fb2b04884af
     blobstore_id: 645552d0-be9a-479f-6692-e77f3638e395
     sha1: a41d085750f5cd6f785d02efe752f3708174224e
+  e07fa80a3e9eb2c0beae3cad38ac914ffa7d56695458b672fa6ee126f2026145:
+    version: e07fa80a3e9eb2c0beae3cad38ac914ffa7d56695458b672fa6ee126f2026145
+    blobstore_id: 825d3bb1-d88e-4120-57e1-7df7bedc3ccb
+    sha1: sha256:3453868a8dd8d102450a4b1b50d3a39a9e17da360c5a79c0ab769372ddba8da9
 format-version: "2"

--- a/jobs/logservice/monit
+++ b/jobs/logservice/monit
@@ -1,10 +1,17 @@
+<%
+port = p('logservice.web.port')
+if_p('logservice.web.tls.port', 'logservice.web.tls.cert', 'logservice.web.tls.key') do
+  port = p('logservice.web.tls.port')
+end
+%>
+
 check process logservice
   with pidfile   /var/vcap/sys/run/bpm/logservice/logservice.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start logservice"
   stop program  "/var/vcap/jobs/bpm/bin/bpm stop  logservice"
   group vcap
   if failed
-    port 8089
+    port <%= port %>
     type tcp
     timeout 30 seconds
   for 2 cycles

--- a/jobs/logservice/spec
+++ b/jobs/logservice/spec
@@ -11,52 +11,63 @@ packages:
   - logservice
 
 properties:
-  logservice.port:
+  logservice.log.level:
+    description: |
+      log level to use for server
+      you can chose: `trace`, `debug`, `info`, `warn`, `error`, `fatal` or `panic`
+    default: "info"
+
+  logservice.web.port:
     default: 8088
     description: Port for listening in http
-  logservice.tls_port:
+
+  logservice.web.tls.port:
     default: 8089
     description: |
       Port for listening in https
       This will be in addition of listening in http
       You will need to set ssl_cert_file and ssl_key_file parameters in addition
-  logservice.external_url:
+  logservice.web.tls.cert:
+    description: "content of an ssl cert in pem format"
+  logservice.web.tls.key:
+    description: "content of an ssl private key in pem format"
+
+  logservice.web.max_keep_alive.disabled:
+    decription: "set true to disable max keep alive"
+    default: false
+  logservice.web.max_keep_alive.duration:
+    decription: "close persistent connection after given duration"
+    default: 4m
+  logservice.web.max_keep_alive.fuzziness:
+    decription: "consider given fraction of duration when computing connection life span"
+    default: 1m
+
+  logservice.db.user:
+    description: "mysql user to connect to"
+  logservice.db.password:
+    description: "mysql password to connect to"
+  logservice.db.host:
+    description: "mysql url to connect to"
+    default: "database.service.cf.internal"
+  logservice.db.database:
+    description: "mysql database name to connect to"
+  logservice.db.port:
+    description: "mysql port to connect to"
+    default: 3306
+  logservice.db.options:
+    description: "additional mysql options for connection"
     default: ""
-    description: |
-      External url which give docs url to user
-      This is an url pointing on this service of course
-      using it let you separate logs part from user part
-  logservice.disallow_logs_from_external:
-    default: false
-    description: |
-      Set to true to not allow to send logs to external url
-      If you want clear separation between user and logs path set it to true
-  logservice.disable_drain_type:
-    default: false
-    description: |
-      By default user can chose what kind of data to retrieve between `logs`, `metrics` or `all` when creating service
-      This will disallow what kind of data user can ask.
-  logservice.prefer_tls:
-    default: false
-    description: |
-      If set to true, forged url for syslog drain endpoint in broker will always use https url
-      This will not let user be able to chose to forward in http or https
-  logservice.syslog_addresses:
-    description: see configuration on https://github.com/orange-cloudfoundry/logs-service-broker#syslog_addresse-configuration
-  logservice.broker.username:
-    description: Broker username basic auth
-  logservice.broker.password:
-    description: Broker password basic auth
-  logservice.syslog_drain_url:
-    description: |
-      this is url used to forge url on syslog drain endpoint
-      this is an url pointing on this service of course
-      e.g.: my-logservice.com
-      note: you don't need to set scheme as http or https like it is dependant of parameter `prefer_tls` or user directive
-  logservice.skip_ssl_validation:
-    description: "not used"
-    default: false
-  logservice.cache_duration:
+  logservice.db.cnx.max_open:
+    description: "Set the maximum number of open connections to the database"
+    default: 100
+  logservice.db.cnx.max_idle:
+    description: "Set the maximum number of connections in the idle"
+    default: 100
+  logservice.db.cnx.max_life:
+    description: "Set the maximum amount of time a connection may be reused. this is a duration which must be write like: `1h` for one hour or `1d` for one day ..."
+    default: "1h"
+
+  logservice.binding_cache.duration:
     description: |
       In order to avoid a lot of request to the database when forwarding logs a cache system is provided
       We recommend to set this value and set it to `always`
@@ -64,39 +75,25 @@ properties:
       Or this can be set to `always` to keep in cache all requested data indefinitely until data still exists
       in db to avoid too much memory usage (check is performed each 24h if set to always)
     default: "always"
-  logservice.mysql.user:
-    description: "mysql user to connect to"
-  logservice.mysql.password:
-    description: "mysql password to connect to"
-  logservice.mysql.host:
-    description: "mysql url to connect to"
-    default: "database.service.cf.internal"
-  logservice.mysql.database:
-    description: "mysql database name to connect to"
-  logservice.mysql.port:
-    description: "mysql port to connect to"
-    default: 3306
-  logservice.mysql.options:
-    description: "additional mysql options for connection"
-    default: ""
-  logservice.mysql.cnx.max_open:
-    description: "Set the maximum number of open connections to the database"
-    default: "100"
-  logservice.mysql.cnx.max_idle:
-    description: "Set the maximum number of connections in the idle"
-    default: "100"
-  logservice.mysql.cnx.max_life:
-    description: "Set the maximum amount of time a connection may be reused. this is a duration which must be write like: `1h` for one hour or `1d` for one day ..."
-    default: "1h"
-  logservice.log_level:
-    description: |
-      log level to use for server
-      you can chose: `trace`, `debug`, `info`, `warn`, `error`, `fatal` or `panic`
-    default: "info"
-  logservice.ssl_cert:
-    description: "content of an ssl cert in pem format"
-  logservice.ssl_key:
-    description: "content of an ssl private key in pem format"
-  logservice.parsing_keys:
-    description: "see configuration on https://github.com/orange-cloudfoundry/logs-service-broker#parsing_key-configuration"
+
+  logservice.broker.username:
+    description: Broker username basic auth
+  logservice.broker.password:
+    description: Broker password basic auth
+  logservice.broker.public_host:
+    description: "Hostname used in borkers' documentation and dashboards"
+  logservice.broker.drain_host:
+    description: "Hostname used to generate broker's syslog_drain url"
+  logservice.broker.force_empty_drain_type:
+    description: set to true to force empty `drain_type` field regardless of what was requested by user
+    default: true
+
+  logservice.forwarder.parsing_keys:
+    description: "See configuration on https://github.com/orange-cloudfoundry/logs-service-broker#parsing_key-configuration"
     default: []
+  logservice.forwarder.allowed_hosts:
+    description: "List of allowed host, incomming requests for any other hosts will be rejected. empty to allow from all"
+    default: []
+
+  logservice.syslog_addresses:
+    description: see configuration on https://github.com/orange-cloudfoundry/logs-service-broker#syslog_addresse-configuration

--- a/jobs/logservice/templates/bpm.yml
+++ b/jobs/logservice/templates/bpm.yml
@@ -5,6 +5,6 @@ processes:
     env:
       CLOUD_FILE: /var/vcap/jobs/logservice/config/config.yml
     limits:
-      open_files: 100000
+      open_files: 25000
     capabilities:
       - NET_BIND_SERVICE

--- a/jobs/logservice/templates/config.yml.erb
+++ b/jobs/logservice/templates/config.yml.erb
@@ -1,39 +1,77 @@
-services:
-  - name: my-config
-    tags: [ "config" ]
-    credentials:
-      port: <%= p('logservice.port') %>
-      tls_port: <%= p('logservice.tls_port') %>
-      external_url: <% if_p('logservice.external_url') do |item| %><%= item %><% end %>
-      disallow_logs_from_external: <%= p('logservice.disallow_logs_from_external') %>
-      disable_drain_type: <%= p('logservice.disable_drain_type') %>
-      prefer_tls: <%= p('logservice.prefer_tls') %>
-      syslog_addresses: <%= p('logservice.syslog_addresses').to_json %>
-      broker_username: "<%= p('logservice.broker.username') %>"
-      broker_password: "<%= p('logservice.broker.password') %>"
-      syslog_drain_url: "<%= p('logservice.syslog_drain_url') %>"
-      skip_ssl_validation: <%= p('logservice.skip_ssl_validation').to_json %>
-      log_level: "<%= p('logservice.log_level') %>"
-      cache_duration: "<%= p('logservice.cache_duration') %>"
-      log_no_color: true
-      log_json: true
-      virtual_host: false
-      sql_cnx_max_open: <%= p('logservice.mysql.cnx.max_open') %>
-      sql_cnx_max_idle: <%= p('logservice.mysql.cnx.max_idle') %>
-      sql_cnx_max_life: <%= p('logservice.mysql.cnx.max_life') %>
-      parsing_keys: <%= p('logservice.parsing_keys').to_json %>
-<% if_p('logservice.ssl_cert') do %>
-<% if_p('logservice.ssl_key') do %>
-      ssl_cert_file: /var/vcap/jobs/logservice/config/ssl_cert.pem
-      ssl_key_file:  /var/vcap/jobs/logservice/config/ssl_key.pem
-<% end %>
-<% end %>
-  - name: mysql
-    credentials:
-      user: "<%= p('logservice.mysql.user') %>"
-      password: "<%= p('logservice.mysql.password') %>"
-      host: "<%= p('logservice.mysql.host') %>"
-      port: "<%= p('logservice.mysql.port') %>"
-      database: "<%= p('logservice.mysql.database') %>"
-      options: "<%= p('logservice.mysql.options') %>"
+<%
+require 'yaml'
 
+credentials = {
+  "log" => {
+    "level"           => p('logservice.log.level'),
+    "json"            => true,
+    "no_color"        => true,
+    "enable_profiler" => false,
+  },
+  "web" => {
+    "port" => p('logservice.web.port'),
+    "tls" => {
+      "port"      => p('logservice.web.tls.port'),
+      "cert_file" => "",
+      "key_file"  => "",
+    },
+    "max_keep_alive" => {
+      "disabled"  => p('logservice.web.max_keep_alive.disabled'),
+      "duration"  => p('logservice.web.max_keep_alive.duration'),
+      "fuzziness" => p('logservice.web.max_keep_alive.fuzziness'),
+    },
+  },
+  "broker" => {
+    "public_host"            => p('logservice.broker.public_host'),
+    "drain_host"             => p('logservice.broker.drain_host'),
+    "username"               => p('logservice.broker.username'),
+    "password"               => p('logservice.broker.password'),
+    "force_empty_drain_type" => p('logservice.broker.force_empty_drain_type'),
+    "virtual_host"           => false,
+  },
+  "forwarder" => {
+    "allowed_hosts"  => p('logservice.forwarder.allowed_hosts'),
+    "parsing_keys"   => p('logservice.forwarder.parsing_keys'),
+  },
+  "binding_cache" => {
+    "duration" => p('logservice.binding_cache.duration'),
+  },
+  "db" => {
+    "sqlite_fallback"      => false,
+    "cnx_max_open"         => p('logservice.db.cnx.max_open'),
+    "cnx_max_idle"         => p('logservice.db.cnx.max_idle'),
+    "cnx_max_life"         => p('logservice.db.cnx.max_life'),
+  },
+  "syslog_addresses" => p('logservice.syslog_addresses')
+}
+
+if_p('logservice.web.tls.cert') do |val|
+  credentials["web"]["tls"]["cert_file"] = "/var/vcap/jobs/logservice/config/ssl_cert.pem"
+  credentials["web"]["tls"]["key_file"]  = "/var/vcap/jobs/logservice/config/ssl_key.pem"
+end
+
+config = {
+  "services" => [
+    {
+      "name" => "my-config",
+      "tags" => [ "config" ],
+      "credentials" => credentials
+    },
+    {
+      "name"         => "mysql",
+      "credentials"  => {
+        "user"     => p('logservice.db.user'),
+        "password" => p('logservice.db.password'),
+        "host"     => p('logservice.db.host'),
+        "port"     => p('logservice.db.port'),
+        "database" => p('logservice.db.database'),
+        "options"  => p('logservice.db.options'),
+      }
+    }
+  ]
+}
+%>
+
+# run with following command:
+# CLOUD_FILE=/var/vcap/jobs/logservice/config/config.yml /var/vcap/packages/logservice/bin/logs-service-broker
+<%= config.to_yaml %>

--- a/jobs/logservice/templates/ssl_cert.pem.erb
+++ b/jobs/logservice/templates/ssl_cert.pem.erb
@@ -1,1 +1,1 @@
-<%= p('logservice.ssl_cert', '') %>
+<%= p('logservice.web.tls.cert', '') %>

--- a/jobs/logservice/templates/ssl_key.pem.erb
+++ b/jobs/logservice/templates/ssl_key.pem.erb
@@ -1,1 +1,1 @@
-<%= p('logservice.ssl_key', '') %>
+<%= p('logservice.web.tls.key', '') %>

--- a/jobs/logservice_alerts/templates/logservice.alerts.yml
+++ b/jobs/logservice_alerts/templates/logservice.alerts.yml
@@ -17,7 +17,6 @@ groups:
         annotations:
           summary: "Logservice has high latency at instance `{{$labels.instance}}`"
           description: "Average process time of logs is greater than `<%= p('logservice_alerts.duration.threshold_ms') %>ms` at instance `{{$labels.instance}}` during the last <%= p('logservice_alerts.duration.evaluation_time') %>"
-
       - alert: LogserviceDropRateTooHigh
         expr: sum(rate(logs_sent_errors_total[10m])) by (instance, org, space, app) > <%= p('logservice_alerts.errors.threshold') %>
         for: <%= p('logservice_alerts.errors.evaluation_time') %>
@@ -27,7 +26,6 @@ groups:
         annotations:
           summary: "Logservice is dropping some logs at instance `{{$labels.instance}}` for app at `{{$labels.org}}/{{$labels.space}}/{{$labels.app}}`"
           description: "Logservice is droping more than `<%= p('logservice_alerts.errors.threshold') %>` logs/s at instance `{{$labels.instance}}` for app at `{{$labels.org}}/{{$labels.space}}/{{$labels.app}}` during the last <%= p('logservice_alerts.errors.evaluation_time') %>"
-
       - alert: LogserviceNoLogs
         expr: (sum(increase(logs_sent_total[15m])) or vector(0)) == 0
         for: <%= p('logservice_alerts.errors.evaluation_time') %>
@@ -43,26 +41,22 @@ groups:
             it's still a serious failure since produced logs are definitely lost.
 
             Please contact Cloud Foundry admin team
-
-      - record: job:logs_forward_duration_sum:increase10m
-        expr: increase(logs_forward_duration_sum[10m])
-      - record: job:logs_forward_duration_count:increase10m
-        expr: increase(logs_forward_duration_count[10m])
-      - alert: LogserviceForwardDurationTooHigh
-        expr: |
-          avg(
-            (job:logs_forward_duration_sum:increase10m / job:logs_forward_duration_count:increase10m) > 0
-          ) by (instance) * 1000 > <%= p('logservice_alerts.forward_duration.threshold_ms') %>
-        for: <%= p('logservice_alerts.forward_duration.evaluation_time') %>
+      - alert: LogserviceDBFailure
+        expr: logs_db_status != 1
+        for: 5m
         labels:
           service: logservice
-          severity: warning
+          severity: critical
         annotations:
-          summary: "Logservice has high latency when forwarding logs on target at instance `{{$labels.instance}}`"
-          description: "Average time for forwarding logs to target is greater than `<%= p('logservice_alerts.forward_duration.threshold_ms') %>ms` at instance `{{$labels.instance}}` during the last <%= p('logservice_alerts.forward_duration.evaluation_time') %>"
+          summary: "Logservice reports communication failure with database"
+          description: |
+            Database could not be reached for more than 5m
+
+            This is a serious failure since produced logs are definitely lost.
+
+            Please contact Cloud Foundry admin team
 
 <% if p('logservice_alerts.cache.enable') %>
-
       - alert: LogserviceSendingLogsWithoutUsingCache
         expr: (sum(increase(logs_sent_without_cache_total[5m])) by (org, space, app) or vector(0)) > <%= p('logservice_alerts.cache.threshold') %>
         for: <%= p('logservice_alerts.cache.evaluation_time') %>
@@ -76,5 +70,4 @@ groups:
             This must be an issue with logservice.
 
             Please contact Cloud Foundry admin team
-
 <% end %>

--- a/jobs/logservice_dashboards/templates/logservice_overview.json
+++ b/jobs/logservice_dashboards/templates/logservice_overview.json
@@ -1,52 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "5.2.4"
-    },
-    {
-      "type": "panel",
-      "id": "grafana-piechart-panel",
-      "name": "Pie Chart",
-      "version": "1.3.3"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "heatmap",
-      "name": "Heatmap",
-      "version": "5.0.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "5.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": "5.0.0"
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -63,12 +15,13 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1544193702097,
+  "id": 131,
+  "iteration": 1597815373500,
   "links": [],
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -89,7 +42,8 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
+      "description": "Shows current status of bosh jobs",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -99,7 +53,7 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 0,
         "y": 1
@@ -121,6 +75,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -128,12 +83,12 @@
       "rangeMaps": [
         {
           "from": "0",
-          "text": "Failing",
+          "text": "Unhealthy",
           "to": "0.99"
         },
         {
           "from": "1",
-          "text": "Running",
+          "text": "Healthy",
           "to": "1"
         }
       ],
@@ -175,7 +130,8 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
+      "description": "Shows current service status based on the nomber of generated errors per second",
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -185,7 +141,7 @@
         "thresholdMarkers": true
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 4,
         "x": 4,
         "y": 1
@@ -207,6 +163,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -260,16 +217,192 @@
       "valueName": "current"
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "prometheus",
+      "description": "Show status of connection to database",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 33,
+      "interval": null,
+      "links": [],
+      "mappingType": 2,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "0",
+          "text": "Failing",
+          "to": "0.99"
+        },
+        {
+          "from": "1",
+          "text": "Healthy",
+          "to": "1"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "min(logs_db_status{instance=~\"$instance\"})",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.5,0.9",
+      "title": "Database",
+      "type": "singlestat",
+      "valueFontSize": "150%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorPostfix": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "description": "Shows current number of processed logs per seconds",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 35,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(rate(logs_sent_total[5m]))",
+          "instant": false,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "L.P.S.",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 4
       },
       "id": 14,
       "panels": [],
-      "title": "Requests",
+      "title": "L.P.S.",
       "type": "row"
     },
     {
@@ -277,14 +410,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
+      "description": "History of successfully processed logs per seconds",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 5,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 5
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "alignAsTable": true,
@@ -296,6 +432,8 @@
         "min": true,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -303,6 +441,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -310,10 +451,10 @@
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
-      "steppedLine": true,
+      "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(logs_sent_total{instance=~\"$instance\"}[10m])) by (instance)",
+          "expr": "sum(rate(logs_sent_total{instance=~\"$instance\"}[5m])) by (instance)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -325,7 +466,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Success Rate (log/s in success)",
+      "title": "Success",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -368,14 +509,17 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
+      "description": "History of logs processing failure per seconds",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 5,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 5
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "alignAsTable": true,
@@ -387,6 +531,8 @@
         "min": true,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": false,
         "total": false,
         "values": true
       },
@@ -394,6 +540,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -404,7 +553,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum(rate(logs_sent_errors_total{instance=~\"$instance\"}[10m])) by (instance) or on() vector(0)",
+          "expr": "sum(rate(logs_sent_errors_total{instance=~\"$instance\"}[5m])) by (instance) or on() vector(0)",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -416,7 +565,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Error Rate (log/s in error)",
+      "title": "Errors",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -455,12 +604,462 @@
       }
     },
     {
+      "columns": [],
+      "datasource": null,
+      "description": "",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 43,
+      "options": {},
+      "pageSize": 10,
+      "showHeader": true,
+      "sort": {
+        "col": 4,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "alias": "L.P.S.",
+          "colorMode": "value",
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Value",
+          "thresholds": [
+            "0",
+            "0"
+          ],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [
+            "0",
+            "0"
+          ],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(logs_sent_total[15m])) by (org, space, app)) > 0",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Success Top 10 ",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "columns": [],
+      "datasource": null,
+      "description": "",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 44,
+      "options": {},
+      "pageSize": 10,
+      "showHeader": true,
+      "sort": {
+        "col": null,
+        "desc": false
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "alias": "L.P.S.",
+          "colorMode": "value",
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Value",
+          "thresholds": [
+            "0",
+            "0"
+          ],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(logs_sent_errors_total[15m])) by (org, space, app)) > 0",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Errors Top 10 ",
+      "transform": "table",
+      "type": "table"
+    },
+    {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 15
+      },
+      "id": 37,
+      "panels": [],
+      "title": "Database",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "Status of communications with database (1 is ok,  0 is not ok)",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 39,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "logs_db_status{instance=~\"$instance\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "Time spent waiting an idle connection to database in the last 15m. This value must be close to 0 as possible.\n",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 41,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(logs_db_cnx_wait_duration{instance=~\"$instance\"}[15m])",
+          "legendFormat": "{{instance}} ",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Cnx wait",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "Number of used and idle connections to database",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 40,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "logs_db_cnx_idle{instance=~\"$instance\"}",
+          "legendFormat": "idle: {{instance}} ",
+          "refId": "A"
+        },
+        {
+          "expr": "logs_db_cnx_used{instance=~\"$instance\"}",
+          "legendFormat": "used: {{instance}} ",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
       },
       "id": 27,
       "panels": [],
@@ -472,15 +1071,18 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
       "decimals": null,
-      "fill": 1,
+      "description": "Percentage of logs processed in less than a given time for selected instance(s)",
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 8,
-        "w": 24,
+        "h": 6,
+        "w": 12,
         "x": 0,
-        "y": 16
+        "y": 27
       },
+      "hiddenSeries": false,
       "id": 25,
       "legend": {
         "alignAsTable": true,
@@ -490,13 +1092,18 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": false,
         "total": false,
         "values": true
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -507,45 +1114,51 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(logs_sent_duration_bucket{le=\"0.005\", instance=~\".*\"}) by (instance,le)  / on(instance) group_left sum(logs_sent_duration_count{instance=~\"$instance\"}) by (instance,le)) * 100",
+          "expr": "sum(logs_sent_duration_bucket{le=\"0.005\", instance=~\"$instance\"}) by (le)  \n/ on()\nsum(logs_sent_duration_count{instance=~\"$instance\"})\n* 100",
           "format": "time_series",
+          "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "5 ms / {{instance}}",
+          "legendFormat": "5 ms",
           "refId": "A"
         },
         {
-          "expr": "(sum(logs_sent_duration_bucket{le=\"0.010\", instance=~\"$instance\"}) by (instance,le)  / on(instance) group_left sum(logs_sent_duration_count{instance=~\"$instance\"}) by (instance,le)) * 100",
+          "expr": "sum(logs_sent_duration_bucket{le=\"0.01\", instance=~\"$instance\"}) by (le)  \n/ on()\nsum(logs_sent_duration_count{instance=~\"$instance\"})\n* 100",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "10 ms / {{instance}}",
+          "legendFormat": "10 ms",
           "refId": "B"
         },
         {
-          "expr": "(sum(logs_sent_duration_bucket{le=\"0.1\", instance=~\"$instance\"}) by (instance,le)  / on(instance) group_left sum(logs_sent_duration_count{instance=~\"$instance\"}) by (instance,le)) * 100",
+          "expr": "sum(logs_sent_duration_bucket{le=\"0.1\", instance=~\"$instance\"}) by (le)  \n/ on()\nsum(logs_sent_duration_count{instance=~\"$instance\"})\n* 100",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "100 ms / {{instance}}",
+          "legendFormat": "100 ms",
           "refId": "C"
         },
         {
-          "expr": "(sum(logs_sent_duration_bucket{le=\"0.25\", instance=~\"$instance\"}) by (instance,le)  / on(instance) group_left sum(logs_sent_duration_count{instance=~\"$instance\"}) by (instance,le)) * 100",
+          "expr": "sum(logs_sent_duration_bucket{le=\"0.25\", instance=~\"$instance\"}) by (le)  \n/ on()\nsum(logs_sent_duration_count{instance=~\"$instance\"})\n* 100",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "250 ms / {{instance}}",
+          "legendFormat": "250 ms",
           "refId": "D"
         },
         {
-          "expr": "(sum(logs_sent_duration_bucket{le=\"0.5\", instance=~\"$instance\"}) by (instance,le)  / on(instance) group_left sum(logs_sent_duration_count{instance=~\"$instance\"}) by (instance,le)) * 100",
+          "expr": "sum(logs_sent_duration_bucket{le=\"0.5\", instance=~\"$instance\"}) by (le)  \n/ on()\nsum(logs_sent_duration_count{instance=~\"$instance\"})\n* 100",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "500ms  / {{instance}}",
+          "legendFormat": "500 ms",
           "refId": "E"
         },
         {
-          "expr": "(sum(logs_sent_duration_bucket{le=\"1\", instance=~\"$instance\"}) by (instance,le)  / on(instance) group_left sum(logs_sent_duration_count{instance=~\"$instance\"}) by (instance,le)) * 100",
+          "expr": "sum(logs_sent_duration_bucket{le=\"1\", instance=~\"$instance\"}) by (le)  \n/ on()\nsum(logs_sent_duration_count{instance=~\"$instance\"})\n* 100",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "1000 ms  / {{instance}}",
+          "legendFormat": "1000 ms",
           "refId": "F"
         }
       ],
@@ -556,7 +1169,7 @@
       "title": "Q.O.S.",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 1,
         "value_type": "individual"
       },
       "type": "graph",
@@ -599,16 +1212,17 @@
         "cardColor": "#b4ff00",
         "colorScale": "sqrt",
         "colorScheme": "interpolateOranges",
-        "exponent": 0.5,
+        "exponent": 0.4,
         "mode": "opacity"
       },
       "dataFormat": "tsbuckets",
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
+      "description": "Heatmap distribution of response times ",
       "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 24
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 27
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -618,6 +1232,7 @@
         "show": false
       },
       "links": [],
+      "options": {},
       "reverseYBuckets": false,
       "targets": [
         {
@@ -655,6 +1270,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -674,103 +1290,14 @@
         "label": "Others",
         "threshold": 0
       },
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
+      "description": "Number of processed logs per instance within given time range {$__range}",
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
-        "h": 9,
-        "w": 8,
+        "h": 8,
+        "w": 12,
         "x": 0,
-        "y": 34
-      },
-      "id": 5,
-      "interval": null,
-      "legend": {
-        "percentage": true,
-        "show": true,
-        "values": true
-      },
-      "legendType": "Right side",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "pieType": "pie",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "expr": "sum(increase(logs_sent_total{}[$__range])) by (org, space)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "{{org}} / {{space}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Log per Space",
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "breakPoint": "50%",
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "${DS_PROMETHEUS}",
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 8,
-        "y": 34
-      },
-      "id": 6,
-      "interval": null,
-      "legend": {
-        "percentage": true,
-        "show": true,
-        "values": true
-      },
-      "legendType": "Right side",
-      "links": [],
-      "maxDataPoints": 3,
-      "nullPointMode": "connected",
-      "pieType": "pie",
-      "strokeWidth": 1,
-      "targets": [
-        {
-          "expr": "sum(increase(logs_sent_total{}[$__range])) by (org)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "intervalFactor": 1,
-          "legendFormat": "{{org}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Log per Org",
-      "type": "grafana-piechart-panel",
-      "valueName": "current"
-    },
-    {
-      "aliasColors": {},
-      "breakPoint": "50%",
-      "cacheTimeout": null,
-      "combine": {
-        "label": "Others",
-        "threshold": 0
-      },
-      "datasource": "${DS_PROMETHEUS}",
-      "fontSize": "80%",
-      "format": "short",
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 16,
         "y": 34
       },
       "id": 28,
@@ -778,12 +1305,15 @@
       "legend": {
         "percentage": true,
         "show": true,
-        "values": false
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
       },
       "legendType": "Right side",
       "links": [],
       "maxDataPoints": 3,
       "nullPointMode": "connected",
+      "options": {},
       "pieType": "pie",
       "strokeWidth": "2",
       "targets": [
@@ -791,13 +1321,13 @@
           "expr": "sum(increase(logs_sent_total{}[$__range])) by (instance)",
           "format": "time_series",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],
-      "title": "Log per Instance",
+      "title": "Instance",
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -809,26 +1339,30 @@
         "label": "Others",
         "threshold": 0
       },
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "prometheus",
+      "description": "Number of processed logs per broked plan within given time range {$__range}",
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 0,
-        "y": 43
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
       },
       "id": 7,
       "interval": null,
       "legend": {
         "percentage": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "values": true
       },
       "legendType": "Right side",
       "links": [],
       "maxDataPoints": 3,
       "nullPointMode": "connected",
+      "options": {},
       "pieType": "pie",
       "strokeWidth": 1,
       "targets": [
@@ -836,13 +1370,13 @@
           "expr": "sum(increase(logs_sent_total{}[$__range])) by (plan_name)",
           "format": "time_series",
           "hide": false,
-          "instant": false,
+          "instant": true,
           "intervalFactor": 1,
           "legendFormat": "{{plan_name}}",
           "refId": "A"
         }
       ],
-      "title": "Log per Plan",
+      "title": "Plan",
       "type": "grafana-piechart-panel",
       "valueName": "current"
     },
@@ -854,14 +1388,114 @@
         "label": "Others",
         "threshold": 0
       },
-      "decimals": null,
+      "datasource": "prometheus",
+      "description": "Number of processed logs per organization within given time range {$__range}",
       "fontSize": "80%",
       "format": "short",
       "gridPos": {
-        "h": 9,
-        "w": 16,
-        "x": 8,
-        "y": 43
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 6,
+      "interval": null,
+      "legend": {
+        "percentage": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "sum(increase(logs_sent_total{}[$__range])) by (org)",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{org}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Organization",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "prometheus",
+      "description": "Number of processed logs per org/space within given time range {$__range}",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 5,
+      "interval": null,
+      "legend": {
+        "percentage": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "values": true
+      },
+      "legendType": "Right side",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "options": {},
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "sum(increase(logs_sent_total{}[$__range])) by (org, space)",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{org}} / {{space}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Space",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": "0"
+      },
+      "datasource": null,
+      "decimals": null,
+      "description": "Number of processed logs per org/space/app within given time range {$__range}",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 50
       },
       "id": 32,
       "interval": null,
@@ -869,19 +1503,22 @@
         "header": "",
         "percentage": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "values": true
       },
       "legendType": "Right side",
       "links": [],
       "maxDataPoints": 3,
       "nullPointMode": "connected",
+      "options": {},
       "pieType": "pie",
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(increase(logs_sent_total{}[$__range])) by (app, org, app)",
+          "expr": "sum(increase(logs_sent_total{}[$__range])) by (org, space, app)",
           "format": "time_series",
-          "instant": false,
+          "instant": true,
           "intervalFactor": 1,
           "legendFormat": "{{org}} / {{space}} / {{app}}",
           "refId": "A"
@@ -889,24 +1526,26 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Log per App",
+      "title": "Application",
       "type": "grafana-piechart-panel",
       "valueName": "current"
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 21,
   "style": "dark",
-  "tags": [],
+  "tags": ["logs"],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
+          "selected": false,
+          "tags": [],
           "text": "All",
           "value": "$__all"
         },
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "prometheus",
         "definition": "",
         "hide": 0,
         "includeAll": true,
@@ -959,5 +1598,5 @@
   "timezone": "",
   "title": "Overview",
   "uid": "Dq4MdSPiz",
-  "version": 2
+  "version": 3
 }

--- a/manifests/logservice.yml
+++ b/manifests/logservice.yml
@@ -47,20 +47,24 @@ instance_groups:
                   env: "{{if hasSuffix .Org \"-staging\" }}dev{{ else }}prod{{ end }}"
                   audience: "mycompagny"
                   fmt: "json"
-            ssl_cert: ((log_service_ssl.certificate))
-            ssl_key: ((log_service_ssl.private_key))
+            web:
+              tls:
+                cert: ((log_service_ssl.certificate))
+                key: ((log_service_ssl.private_key))
             broker:
+              public_host: logservice.((system_domain))
+              drain_host: logservice.service.cf.internal
               username: logservice-broker
               password: ((logservice-broker-password))
-            syslog_drain_url: https://logservice.service.cf.internal:8089
-            skip_ssl_validation: false
-            mysql:
+            db:
               user: logservice
               password: ((logservice-mysql-password))
               host: database.service.cf.internal
               database: logservice
-            external_url: https://logservice.((system_domain))
-            disallow_logs_from_external: true
+            forwarder:
+              allowed_hosts:
+                - logservice.service.cf.internal
+
       - name: route_registrar
         release: routing
         consumes:
@@ -106,13 +110,12 @@ stemcells:
     os: ubuntu-xenial
     version: latest
 
-manifest_version: v1.5
+manifest_version: v2.0.0
 
 releases:
   - name: logservice
-    version: "1.11"
-    url: https://github.com/orange-cloudfoundry/logservice-release/releases/download/v1.11/logservice-1.11.tgz
-    sha1: 611d5f107411ddd2ed37ee5b8a5a8b9cd6102b2c
+    version: 2.2.0
+    url: https://github.com/orange-cloudfoundry/logservice-release/releases/download/v2.0.0/logservice-2.0.0.tgz
   - name: bpm
     version: latest
   - name: routing

--- a/manifests/operations/disable-drain-type.yml
+++ b/manifests/operations/disable-drain-type.yml
@@ -1,3 +1,0 @@
-- type: replace
-  path: /instance_groups/name=logservice/jobs/name=logservice/properties/logservice/disable_drain_type?
-  value: true

--- a/packages/golang-1-linux/spec.lock
+++ b/packages/golang-1-linux/spec.lock
@@ -1,2 +1,2 @@
 name: golang-1-linux
-fingerprint: ca6dd90b53ae3a3712787e5a121c61605ccacca1e5b97cdc9e966e7faa298a9e
+fingerprint: e07fa80a3e9eb2c0beae3cad38ac914ffa7d56695458b672fa6ee126f2026145


### PR DESCRIPTION
* bump golang-1-linux to go1.14
* bump [logs-service-broker !6](https://github.com/orange-cloudfoundry/logs-service-broker/pull/6)
* rework config template and spec according logs-service-broker update
* rework grafana dashboard
* add alert about database connection status
* variabilize monit script check port