### PR TITLE
remove builtin broker registrar job

### DIFF
--- a/manifests/logservice.yml
+++ b/manifests/logservice.yml
@@ -8,23 +8,6 @@ instance_groups:
     jobs:
       - name: bpm
         release: bpm
-      - name: broker-registrar
-        release: logservice
-        properties:
-          cf:
-            api_url: https://api.((system_domain))
-            username: admin
-            password: ((/((director_name))/cf/cf_admin_password))
-            skip_ssl_validation: true
-          logservice:
-            broker:
-              host: logservice.service.cf.internal
-              protocol: https
-              port: 8089
-              name: logs
-              username: logservice-broker
-              password: ((logservice-broker-password))
-              public_plans: [loghost]
       - name: logservice
         release: logservice
         properties:

--- a/manifests/operations/cf/diego-cell-trust-service.yml
+++ b/manifests/operations/cf/diego-cell-trust-service.yml
@@ -1,3 +1,0 @@
-- type: replace
-  path: /addons/name=loggr-syslog-agent/jobs/name=loggr-syslog-agent/properties/drain_ca_cert?
-  value: ((cc_tls.ca))


### PR DESCRIPTION
* remove built-in broker registrar job, please use to-be-published `registrar-boshrelease`
* remove diego-cell-trust-service.yml since cf deployment must not depends on logservice-boshrelease