### PR TITLE
filter LogserviceDropRateTooHigh alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # logservice-boshrelease
 
-It's a bosh release for deploying [logs-service-broker](https://github.com/orange-cloudfoundry/logs-service-broker) and provide 
-also a drop in replacement of parsing app logs and metrics on a [logsearch-boshrelease](https://github.com/cloudfoundry-community/logsearch-boshrelease).
-It also include dashboards for grafana and alerts for prometheus for logs-service-broker.
+It's a bosh release for deploying [logs-service-broker](https://github.com/orange-cloudfoundry/logs-service-broker)
+and also provide a drop in replacement of parsing app logs and metrics on a [logsearch-boshrelease](https://github.com/cloudfoundry-community/logsearch-boshrelease).
+It also includes dashboards for grafana and alerts for prometheus for logs-service-broker.
 
 Logs-service-broker is a broker server for logs parsing (with custom parsing patterns given by user or operator) and 
-forwarding to one or multiple syslog endpoint in rfc 5424 syslog format.
-Take care that logs-service-broker will always provide json encoded format to final syslogs endpoint(s).
+forwarding to one or multiple syslog endpoint in the [RFC 5424](https://datatracker.ietf.org/doc/rfc5424/) syslog format.
+Take care that logs-service-broker will always provide a json encoded format to final syslogs endpoint(s).
 
-It is for now tied to cloud foundry for different types of logs received by this platform.
+It is currently tied to Cloud Foundry for different types of logs received by this platform.
 
-This is compliant with the spec [open service broker api](https://www.openservicebrokerapi.org/) for 
+This is compliant with the spec [Open Service Broker API](https://www.openservicebrokerapi.org/) for 
 [syslog drain](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#log-drain).
 
-## Deploy for cloud foundry with dashboards and alerts on your prometheus
+## Deploy for Cloud Foundry with dashboards and alerts on your Prometheus
 
 1. Add ops files [adapter-add-service-certs.yml](/manifests/operations/cf/adapter-add-service-certs.yml) and 
-[atabase-enable-logservice.yml](/manifests/operations/cf/database-enable-logservice.yml) on your cloud foundry deployment
-2. Add ops file [monitor-logservice.yml](/manifests/operations/prometheus/monitor-logservice.yml) on your prometheus deployment.
-2. Deploy manifest [logservice.yml](/manifests/logservice.yml)
+[database-enable-logservice.yml](/manifests/operations/cf/database-enable-logservice.yml) on your Cloud Foundry deployment.
+2. Add ops file [monitor-logservice.yml](/manifests/operations/prometheus/monitor-logservice.yml) on your Prometheus deployment.
+2. Deploy manifest [logservice.yml](/manifests/logservice.yml).
 
 ## Replace logsearch apps parsing by logservice
 
 1. Place runtime-config [logsearch-dns.yml](/manifests/runtime-configs/logsearch-dns.yml) with command:
-`bosh update-runtime-config manifests/runtime-configs/logsearch-dns.yml --name=logsearch-dns`. This will set a bosh dns config to
-know how to hit logstash on logsearch by logservice.
-2. Redeploy logservice to know this new bosh-dns entry
-3. Add ops file [add-logservice.yml](/manifests/operations/logsearch/add-logservice.yml) to your logsearch deployment
+`bosh update-runtime-config manifests/runtime-configs/logsearch-dns.yml --name=logsearch-dns`.
+ This will set a bosh DNS config to know how to hit logstash on logsearch by logservice.
+3. Redeploy logservice to know this new bosh-dns entry.
+4. Add ops file [add-logservice.yml](/manifests/operations/logsearch/add-logservice.yml) to your logsearch deployment.

--- a/jobs/logservice_alerts/spec
+++ b/jobs/logservice_alerts/spec
@@ -21,6 +21,9 @@ properties:
     description: "Average forward duration too high evaluation time"
     default: 5m
 
+  logservice_alerts.errors.filter:
+    description: "Filter to apply on the metrics for the alarm (i.e.: app=\"reference\")"
+    default: ''
   logservice_alerts.errors.threshold:
     description: "Forward drop rate too high threshold"
     default: 0

--- a/jobs/logservice_alerts/templates/logservice.alerts.yml
+++ b/jobs/logservice_alerts/templates/logservice.alerts.yml
@@ -60,7 +60,7 @@ groups:
           summary: "Logservice has high latency at instance `{{$labels.instance}}`"
           description: "Average process time of logs is greater than `<%= p('logservice_alerts.duration.threshold_ms') %>ms` at instance `{{$labels.instance}}` during the last <%= p('logservice_alerts.duration.evaluation_time') %>"
       - alert: LogserviceDropRateTooHigh
-        expr: sum(rate(logs_sent_errors_total[10m])) by (instance, org, space, app) > <%= p('logservice_alerts.errors.threshold') %>
+        expr: sum(rate(logs_sent_errors_total{<%= p('logservice_alerts.errors.filter') %>}[10m])) by (instance, org, space, app) > <%= p('logservice_alerts.errors.threshold') %>
         for: <%= p('logservice_alerts.errors.evaluation_time') %>
         labels:
           service: logservice

--- a/jobs/logservice_alerts/templates/logservice.alerts.yml
+++ b/jobs/logservice_alerts/templates/logservice.alerts.yml
@@ -67,7 +67,7 @@ groups:
           severity: critical
         annotations:
           summary: "Logservice is dropping some logs at instance `{{$labels.instance}}` for app at `{{$labels.org}}/{{$labels.space}}/{{$labels.app}}`"
-          description: "Logservice is droping more than `<%= p('logservice_alerts.errors.threshold') %>` logs/s at instance `{{$labels.instance}}` for app at `{{$labels.org}}/{{$labels.space}}/{{$labels.app}}` during the last <%= p('logservice_alerts.errors.evaluation_time') %>"
+          description: "Logservice is dropping more than `<%= p('logservice_alerts.errors.threshold') %>` logs/s at instance `{{$labels.instance}}` for app at `{{$labels.org}}/{{$labels.space}}/{{$labels.app}}` during the last <%= p('logservice_alerts.errors.evaluation_time') %>"
       - alert: LogserviceNoLogs
         expr: (sum(increase(logs_sent_total[<%= p('logservice_alerts.nologs.span_time') %>])) or vector(0)) == 0
         for: <%= p('logservice_alerts.nologs.evaluation_time') %>


### PR DESCRIPTION
Let the users add a filter to the `LogserviceDropRateTooHigh`,
for example to a reference application.

Questions:
1. shall we apply the filter to other alerts (or make one per alert)?
2. should the record rules be filtered as well to avoid using disk space unnecessarily